### PR TITLE
fix etcd encoding/decoding and range queries

### DIFF
--- a/storage/etcd-kv.test.ts
+++ b/storage/etcd-kv.test.ts
@@ -1,9 +1,20 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { EtcdKVStorage, EtcdStorageProvider, encodeBase64, type EtcdConfig } from './etcd-kv';
+import {
+  EtcdKVStorage,
+  EtcdStorageProvider,
+  encodeBase64,
+  incrementString,
+  type EtcdConfig,
+} from './etcd-kv';
 import type { KVGetOptions, KVListOptions } from './interfaces';
 
 // Mock fetch globally
 global.fetch = vi.fn();
+
+// Helper function to calculate expected range_end
+function getExpectedRangeEnd(prefix: string): string {
+  return encodeBase64(incrementString(prefix));
+}
 
 describe('EtcdKVStorage', () => {
   let storage: EtcdKVStorage;
@@ -510,7 +521,7 @@ describe('EtcdKVStorage', () => {
           method: 'POST',
           body: JSON.stringify({
             key: 'ZHAxL3Rlc3QtbmFtZXNwYWNlL3Rlc3Qt',
-            range_end: 'ZHAxL3Rlc3QtbmFtZXNwYWNlL3Rlc3QtAA==',
+            range_end: getExpectedRangeEnd('dp1/test-namespace/test-'),
             limit: 10,
           }),
         })
@@ -539,7 +550,7 @@ describe('EtcdKVStorage', () => {
         expect.objectContaining({
           body: JSON.stringify({
             key: 'ZHAxL3Rlc3QtbmFtZXNwYWNlLw==',
-            range_end: 'ZHAxL3Rlc3QtbmFtZXNwYWNlLwA=',
+            range_end: getExpectedRangeEnd('dp1/test-namespace/'),
             limit: 1000,
           }),
         })


### PR DESCRIPTION
Fix for the server issue: 507c5d378c73454b41f5b94501499de0fa2114b8

```
Error putting key 
  playlist:id:5e2b9347-c616-4c09-a3e0-4dd202b2eb93 to etcd: 
  DOMException [InvalidCharacterError]: Invalid character
    at btoa (node:buffer:1288:11)
    at EtcdKVStorage.put 
  (file:///app/dist/server.js:91:18)
    at StorageService.savePlaylist 
  (file:///app/dist/server.js:2642:28)
    at QueueProcessorService.handleCreatePlaylist 
  (file:///app/dist/server.js:3249:31)
    at QueueProcessorService.processMessage 
  (file:///app/dist/server.js:3232:20)
    at file:///app/dist/server.js:3204:20
    at Array.map (<anonymous>)
    at QueueProcessorService.processBatch 
  (file:///app/dist/server.js:3202:37)
    at processWriteOperations 
  (file:///app/dist/server.js:3315:33)
    at file:///app/dist/server.js:4143:26
```

when creating playlists which contain emojis.

And fix for the range queries (e.g. `GET /api/v1/playlists`) not returning anything: b45db355f7483d965d363e1f4670982ae4bf0eb3

Seems to work locally and `npm test -- storage/etcd-kv.test.ts`